### PR TITLE
🧪 Add unit tests for determineDirectory utility

### DIFF
--- a/src/utils/fileUtils.test.ts
+++ b/src/utils/fileUtils.test.ts
@@ -1,0 +1,27 @@
+import { determineDirectory } from "./fileUtils";
+
+describe("determineDirectory", () => {
+  it("should return the directory path for a typical absolute path", () => {
+    expect(determineDirectory("/path/to/file.jpg")).toBe("/path/to");
+  });
+
+  it("should return empty string for a path with only a filename (no slash)", () => {
+    expect(determineDirectory("file.jpg")).toBe("");
+  });
+
+  it("should return empty string for a path with only a single slash at the beginning", () => {
+    expect(determineDirectory("/file.jpg")).toBe("");
+  });
+
+  it("should return the parent directory for a path ending in a slash", () => {
+    expect(determineDirectory("/path/to/dir/")).toBe("/path/to/dir");
+  });
+
+  it("should handle paths with multiple slashes correctly", () => {
+    expect(determineDirectory("/a/b/c/d.txt")).toBe("/a/b/c");
+  });
+
+  it("should return empty string for an empty input", () => {
+    expect(determineDirectory("")).toBe("");
+  });
+});


### PR DESCRIPTION
Added unit tests for the `determineDirectory` utility function in `src/utils/fileUtils.ts`. These tests ensure that the function correctly extracts the directory path from various types of file paths and handles edge cases such as paths without slashes or empty strings. Coverage includes typical absolute paths, paths with a single leading slash, paths ending in a slash, and multi-level directory paths.

---
*PR created automatically by Jules for task [17147878825120356406](https://jules.google.com/task/17147878825120356406) started by @BlueGeckoJP*