### PR TITLE
🧹 remove unused export ComparisonChildListProps

### DIFF
--- a/src/components/TabBar/ComparisonChildList.tsx
+++ b/src/components/TabBar/ComparisonChildList.tsx
@@ -3,7 +3,7 @@ import type {
   SingleTabState,
 } from "../../store/tabStoreState";
 
-export type ComparisonChildListProps = {
+type ComparisonChildListProps = {
   isComp: boolean;
   expanded: boolean;
   comparisonTab: ComparisonTabState;


### PR DESCRIPTION
🎯 **What:** The code health issue addressed was an unused export `ComparisonChildListProps` in `src/components/TabBar/ComparisonChildList.tsx`.
💡 **Why:** Removing unused exports improves maintainability and readability of the codebase by keeping the public API clean and following the principle of least visibility.
✅ **Verification:** I confirmed that `ComparisonChildListProps` is not used anywhere else in the codebase using `grep`. The change was also reviewed and confirmed to be correct.
✨ **Result:** The `ComparisonChildListProps` type is now local to its file, reducing unnecessary exposure.

---
*PR created automatically by Jules for task [10329367359254921083](https://jules.google.com/task/10329367359254921083) started by @BlueGeckoJP*